### PR TITLE
Show progress while rspecs are executing

### DIFF
--- a/plugin/sweet-vim-rspec.vim
+++ b/plugin/sweet-vim-rspec.vim
@@ -5,7 +5,7 @@ if !exists('g:SweetVimRspecPlugin')
 endif
 
 function! SweetVimRspecRun(kind)
-  echomsg "Running Specs..."
+  echomsg "Running Specs: "
   sleep 10m " Sleep long enough so MacVim redraws the screen so you can see the above message
 
   if !exists('g:SweetVimRspecUseBundler')
@@ -53,7 +53,8 @@ function! SweetVimRspecRun(kind)
 
   let g:SweetVimRspecErrorFile = tempname()
   execute 'silent! wall'
-  cgete system(t:SweetVimRspecExecutable . t:SweetVimRspecTarget . " 2>" . g:SweetVimRspecErrorFile)
+  cgete s:PollingSystemCall(t:SweetVimRspecExecutable . t:SweetVimRspecTarget . " 2>" . g:SweetVimRspecErrorFile)
+  sleep 400m " Opening the cwindow clears the output in the message buffer, delay it a bit so you can actually read it
   botright cwindow
   cw
   setlocal foldmethod=marker
@@ -68,9 +69,47 @@ function! SweetVimRspecRun(kind)
 
   let l:oldCmdHeight = &cmdheight
   let &cmdheight = 2
-  echo "Done"
   let &cmdheight = l:oldCmdHeight
 endfunction
+
+function! s:PollingSystemCall(systemcall)
+  " TODO: Prints that are embedded in tests are making trouble, somehow redirect them?
+  let progress_length = 0
+  let output_file = tempname()
+  let pid = system(a:systemcall . " > " . output_file . " & echo $!") " the echo $! returns the process id
+  let running = 1
+  while running 
+    let progress =  system("cat " . output_file . " | head -1")
+    let old_length = progress_length
+    let progress_length = strlen(progress)
+    let new_output = strpart(progress, old_length, progress_length - old_length)
+    call s:ColoredOutput(substitute(new_output, "\n", "", "")) " remove line breaks before coloring
+    let running = len(split(system("ps -p ".pid),"\n")) > 1 " the ps command displays column headings and below the info about the process, if it only returns one line the process does not exist
+    sleep 100m
+  endwhile
+  echohl Special | echon " √Done" | echohl Normal
+  let result = readfile(output_file)[1:] " Omitting the first line, since it contains the progress indicators
+  call delete(output_file)
+  return result
+endfunction
+
+function! s:ColoredOutput(string)
+  let i = 0
+  while i < len(a:string)
+    let char = strpart(a:string, i, 1)
+    if(char == "F")
+      echohl WarningMsg
+    elseif (char == "*")
+      echohl Todo
+    elseif (char == ".")
+      echohl Special
+    end
+    echon char
+    let i += 1
+    echohl Normal
+  endwhile
+endfunction
+
 command! SweetVimRspecRunFile call SweetVimRspecRun("File")
 command! SweetVimRspecRunFocused call SweetVimRspecRun("Focused")
 command! SweetVimRspecRunPrevious call SweetVimRspecRun("Previous")

--- a/plugin/sweet_vim_rspec2_formatter.rb
+++ b/plugin/sweet_vim_rspec2_formatter.rb
@@ -4,6 +4,9 @@ module RSpec
   module Core
     module Formatters
       class SweetVimRspecFormatter < BaseTextFormatter
+        @@failures = []
+        @@passes = []
+        @@pending = []
 
         def example_failed(example)
           data = ""
@@ -19,7 +22,8 @@ module RSpec
           data << "\n+-+ Backtrace\n"
           data << exception.backtrace.join("\n")
           data << "\n-+-\n" * 2
-          output.puts data
+          @@failures << data
+          output.print "F"
         end
 
         def example_pending(example)
@@ -30,19 +34,26 @@ module RSpec
           pending = example.execution_result[:pending_message]
           data << example.location + ": in `#{example.description}'"
           data << "\n\n-+-\n"
-          output.puts data
+          @@pending << data
+          output.print "*"
         end
 
         def example_passed(example)
           if ENV['SWEET_VIM_RSPEC_SHOW_PASSING'] == 'true'
-            output.puts "[PASS] #{example.full_description}\n"
+            @@passes << "[PASS] #{example.full_description}\n"
           end
+          output.print "."
         end
 
-        def dump_failures *args; end
+        def dump_failures
+          output.puts @@failures.join("")
+        end
 
-        def dump_pending *args; end
-
+        def dump_pending
+          output.puts 
+          output.puts @@pending.join("")
+        end
+ 
         def message msg; end
 
         def dump_summary(*);end
@@ -60,4 +71,5 @@ module RSpec
     end 
   end 
 end 
+
 


### PR DESCRIPTION
I changed the rspec formatter a bit and piped the output of rspec into a file. While the rspec process is running I am polling for changes to the output file and showing them in a progress bar.
![](https://img.skitch.com/20110927-ck7mwdj5ubce3p15d1b3n421t.jpg)
